### PR TITLE
Add a cacheScope option to specify an alternate cache scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ nodeModuleCache.start(opts);
 ```
 
 Start accepts an options parameter with two options
+   * ```cacheScope``` - alternate cache scope. Defaults to ```process.cwd()```
    * ```cacheFile``` - alternate cache file location. Defaults to ```{os.tmpdir()}/module-locations-cache.json```
    * ```startupFile``` - alternate startup file location. Defaults to ```./node_modules/module-locations-cache.json```, relative to the ```process.cwd()```
    * ```cacheKiller``` - used to invalidate the cache. Normally one will pass the application version number assuming that a different version

--- a/index.js
+++ b/index.js
@@ -11,12 +11,12 @@ var options = {
   saveTimeout: 1000,
   startupFile: DEFAULT_STARTUP_FILE,
   cacheFile: DEFAULT_CACHE_FILE,
+  cacheScope: process.cwd(),
   cacheKiller: versionNumber(),
   statusCallback: function(message) {}
 };
 var existsSyncCache = {};
 var filenameLookup = newFilenameLookup();
-var cwd = process.cwd();
 var stats = {
   cacheHit: 0,
   cacheMiss: 0,
@@ -28,8 +28,8 @@ var stats = {
 };
 
 function toCanonicalPath(filename) {
-  var relative = path.relative(cwd, filename);
-  // do not cache files outside of the process.cwd() scope
+  var relative = path.relative(options.cacheScope, filename);
+  // do not cache files outside of the cache scope
   if (relative.indexOf("..") == 0)
     return undefined;
 
@@ -37,7 +37,7 @@ function toCanonicalPath(filename) {
 }
 
 function toAbsolutePath(filename) {
-  return path.join(cwd, filename);
+  return path.join(options.cacheScope, filename);
 }
 
 function resolveFilenameOptimized(request, parent) {
@@ -114,6 +114,8 @@ function start(opts) {
   if (opts) {
     if (opts.cacheFile)
       options.cacheFile = opts.cacheFile;
+    if (opts.cacheScope)
+      options.cacheScope = opts.cacheScope;
     if (opts.saveTimeout)
       options.saveTimeout = opts.saveTimeout;
     if (opts.startupFile)

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "version": "1.0.9",
   "description": "Speeding up node boot time by caching for filesystem location of node modules",
   "main": "index.js",
-  "homepage": "https://github.com/balena-io-playground/fast-boot",
+  "homepage": "https://github.com/balena-io-modules/fast-boot",
   "author": "Yoav Abrahami",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git@github.com:balena-io-playground/fast-boot.git"
+    "url": "git@github.com:balena-io-modules/fast-boot.git"
   },
   "bugs": {
-    "url": "https://github.com/balena-io-playground/fast-boot/issues"
+    "url": "https://github.com/balena-io-modules/fast-boot/issues"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
This is useful when combining fast-boot2 with a globally installed
module, as in that case you are likely to want the scope to be relative
to the install directory rather than the cwd

Change-type: minor